### PR TITLE
Add FOSS4G 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ### Asia
 
   - FOSS4G Asia 2026, https://foss4g.asia/2026/, Nashik, 21--25 January 2026
+  - FOSS4G 2026, (no website yet?), Hiroshima, 30 August--5 September 2026
 
 ### Europe
 


### PR DESCRIPTION
Hope to see you in Japan!

Guessing from this year's and last year's FOSS4G, the website URL will probably be <https://2026.foss4g.org/>, but it seems there's no website yet.

Also, I couldn't find the official announcement about the schedule. But, I found several documents (in Japanese, e.g. [this slide](https://speakerdeck.com/wata909/2026nian-niglobal-foss4ggaguang-dao-nikimasu-osgeo-dot-jptofoss4gnogoshao-jie?slide=30)) describes this schedule, so I bet this is almost fixed.

Announcement by OSGeo JP: https://www.osgeo.jp/archives/4501