### PR TITLE
Add "State of the Map 2026" event to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - FOSS4G Europe 2026, https://2026.europe.foss4g.org/, Timișoara, România, 29 June - 3 July 2026
   - UseR! 2026 Conference, https://www.r-project.org/conferences/, Warsaw, 6--9 July 2026
   - AGIT 2026, https://agit.at/en/, Salzburg, 8--9 July 2026
+  - State of the Map 2026, https://2026.stateofthemap.org/, Paris, 28--30 August 2026
   - The 17th Conference on Spatial Information Theory (COSIT), https://www.cosit2026.uk/, York, 22--25 September 2026
   - QGIS conference 2026, https://conference.qgis.org, Switzerland, 5-6 October 2026
 


### PR DESCRIPTION
Add global OSM conference:
* https://2026.stateofthemap.org/
* https://wiki.openstreetmap.org/wiki/State_of_the_Map_2026

> "State of the Map is the annual event for all mappers and OpenStreetMap users. In 2026 the State of the Map conference will be taking place in Paris and online. It will be a three day conference packed with talks, workshops, discussion rounds and more."